### PR TITLE
Bug fix for xslts with spaces in the name

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -68,7 +68,7 @@ function dgi_saxon_helper_transform($input, $output, $xslt, array $params = arra
   $command = variable_get('dgi_saxon_helper_executable', DGI_SAXON_HELPER_DEFAULT_EXECUTABLE_PATH);
 
   try {
-    $process = proc_open("$command -versionmsg:off -ext:on - $xslt_path $param_string",
+    $process = proc_open("$command -versionmsg:off -ext:on - '$xslt_path' $param_string",
       array(
         0 => $input,
         1 => $output,


### PR DESCRIPTION
Use case where user uses an XSLT template that has a space in its name. Example "sample template.xsl"

This create a bad key pair error within saxon."/usr/bin/saxonb-xslt -versionmsg:off -ext:on -it:root /var/www/drupal7/sites/default/files/sample template.xsl 'label=Volume C page 77'"

Reference:
https://github.com/discoverygarden/islandora_spreadsheet_ingest/pull/22