### PR TITLE
Use a non-printable record delimiter over new line

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -67,7 +67,7 @@ function dgi_saxon_helper_transform($input, $output, $xslt, array $xslt_params =
 
   $parameters = fopen('php://temp', 'r+b');
   foreach ($xslt_params as $xsl_key => $xsl_value) {
-    fwrite($parameters, "$xsl_key=$xsl_value\n");
+    fwrite($parameters, "$xsl_key=$xsl_value\036");
   }
   fseek($parameters, 0);
   $saxon_params_escape = function ($key, $value) {

--- a/shell_scripts/saxonb-xslt.sh
+++ b/shell_scripts/saxonb-xslt.sh
@@ -6,7 +6,7 @@ saxon_params=$2
 transform_file=$3
 
 declare -a escaped_array
-while read -u 3 p; do
+while read -d$'\036' -u 3 p; do
   escaped_array+=("$p")
 done
 


### PR DESCRIPTION
By utilizing this delimiter (U+001F - record separator https://en.wikipedia.org/wiki/Delimiter), we avoid delimiter collision. In this case, new lines in blobs of text (such as an abstract description) would be interpreted as delimiters causing the bash array of key value pairs to be inaccurate. This leads to a bad param=value pair exception exposed as a DgiSaxonHelperTransformationException.